### PR TITLE
Make the plugin work with newest possible versions of dependencies

### DIFF
--- a/mkdocs_plugin_commonmark/__init__.py
+++ b/mkdocs_plugin_commonmark/__init__.py
@@ -1,26 +1,35 @@
+from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin
-from mkdocs.structure.pages import Page, _RelativePathExtension
+from mkdocs.structure.files import Files
+from mkdocs.structure.pages import (
+    Page, _ExtractTitleTreeprocessor, _RelativePathTreeprocessor
+)
 
 from mkdocs.structure.toc import get_toc
 from .mistletoe_interop import MarkdownInterop
 
 
-def render(self, config, files):
+def render(self, config: MkDocsConfig, files: Files) -> None:
     """
     Convert the Markdown source file to HTML as per the config.
     """
-
-    extensions = [
-        _RelativePathExtension(self.file, files)
-    ] + config['markdown_extensions']
+    if self.markdown is None:
+        raise RuntimeError("`markdown` field hasn't been set (via `read_source`)")
 
     md = MarkdownInterop(
-        extensions=extensions,
-        extension_configs=config['mdx_configs'] or {}
+        extensions=config['markdown_extensions'],
+        extension_configs=config['mdx_configs'] or {},
     )
+
+    relative_path_ext = _RelativePathTreeprocessor(self.file, files, config)
+    relative_path_ext._register(md)
+
+    extract_title_ext = _ExtractTitleTreeprocessor()
+    extract_title_ext._register(md)
 
     self.content = md.convert(self.markdown)
     self.toc = get_toc(getattr(md, 'toc_tokens', []))
+    self._title_from_render = extract_title_ext.title
 
 # Page.render = render
 

--- a/mkdocs_plugin_commonmark/__init__.py
+++ b/mkdocs_plugin_commonmark/__init__.py
@@ -1,9 +1,8 @@
+import markdown
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import Files
-from mkdocs.structure.pages import (
-    Page, _ExtractTitleTreeprocessor, _RelativePathTreeprocessor
-)
+from mkdocs.structure.pages import Page
 
 from mkdocs.structure.toc import get_toc
 from .mistletoe_interop import MarkdownInterop
@@ -13,33 +12,18 @@ def render(self, config: MkDocsConfig, files: Files) -> None:
     """
     Convert the Markdown source file to HTML as per the config.
     """
-    if self.markdown is None:
-        raise RuntimeError("`markdown` field hasn't been set (via `read_source`)")
-
-    md = MarkdownInterop(
-        extensions=config['markdown_extensions'],
-        extension_configs=config['mdx_configs'] or {},
-    )
-
-    relative_path_ext = _RelativePathTreeprocessor(self.file, files, config)
-    relative_path_ext._register(md)
-
-    extract_title_ext = _ExtractTitleTreeprocessor()
-    extract_title_ext._register(md)
-
-    self.content = md.convert(self.markdown)
-    self.toc = get_toc(getattr(md, 'toc_tokens', []))
-    self._title_from_render = extract_title_ext.title
+    original_markdown = markdown.Markdown
+    markdown.Markdown = MarkdownInterop
+    self._original_render(config, files)
+    markdown.Markdown = original_markdown
 
 # Page.render = render
 
 class CommonMark(BasePlugin):
-    original_render = None
-
     def on_pre_build(self, config, **kwargs):
-        if not self.original_render:
-            self.original_render = Page.render
+        if not hasattr(Page, "_original_render"):
+            Page._original_render = Page.render
         Page.render = render
 
     def on_post_build(self, config, **kwargs):
-        Page.render = self.original_render
+        Page.render = Page._original_render

--- a/mkdocs_plugin_commonmark/mistletoe_interop.py
+++ b/mkdocs_plugin_commonmark/mistletoe_interop.py
@@ -155,9 +155,12 @@ class ETreeRenderer(BaseRenderer):
         html._charref = self._stdlib_charref
 
     def render_to_plain(self, token):
-        if hasattr(token, 'children'):
+        if token.children:
             inner = [self.render_to_plain(child) for child in token.children]
             return ''.join(inner)
+        if isinstance(token, span_token.Image):
+            # TODO: it doesn't seem to matter what is returned from this method anyway!
+            return ""
         return self.escape_html(token.content)
 
     def render_inner(self, token):

--- a/mkdocs_plugin_commonmark/mistletoe_interop.py
+++ b/mkdocs_plugin_commonmark/mistletoe_interop.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import contextmanager
 from itertools import chain
 from urllib.parse import quote
+from xml.etree import ElementTree as ET
 from mistletoe.block_token import HTMLBlock
 from mistletoe.span_token import HTMLSpan
 from mistletoe.base_renderer import BaseRenderer
@@ -19,7 +20,7 @@ else:
 
 import markdown
 from markdown import util
-from markdown.util import etree, text_type, AtomicString
+from markdown.util import AtomicString
 
 from mistletoe import (Document, block_tokenizer, block_token, span_token, token)
 from mistletoe.block_token import _token_types as _block_token_types
@@ -51,7 +52,7 @@ def unsafe_wrap(text):
     '''
     # Note that "True" is not serializable by most serializers,
     # to guard against that the element itself is never rendered.
-    el = etree.Element('', unsafe=True)
+    el = ET.Element('', unsafe=True)
     el.text = text
     return el
 
@@ -67,7 +68,7 @@ def safe_concat(a, b):
 
 def splice(x):
     # unfortunately, str is iterable
-    if (isinstance(x, text_type) or
+    if (isinstance(x, str) or
         # fortunately, Element is iterable but has no __iter__
         not hasattr(x, '__iter__')):
         yield x
@@ -213,7 +214,7 @@ class ETreeRenderer(BaseRenderer):
         buf = ''
 
         for t in splice(inner):
-            if isinstance(t, util.text_type):
+            if isinstance(t, str):
                 buf += t
             else:
                 # must be an etree.Element
@@ -235,41 +236,41 @@ class ETreeRenderer(BaseRenderer):
         return el
 
     def render_strong(self, token):
-        el = etree.Element('strong')
+        el = ET.Element('strong')
         return self.append_elems(el, self.render_inner(token))
 
     def render_emphasis(self, token):
-        el = etree.Element('em')
+        el = ET.Element('em')
         return self.append_elems(el, self.render_inner(token))
 
     def render_inline_code(self, token):
-        el = etree.Element('code')
+        el = ET.Element('code')
         el.text = AtomicString(html.escape(token.children[0].content)
             .replace('&#x27;', "'"))
         return el
 
     def render_strikethrough(self, token):
-        el = etree.Element('del')
+        el = ET.Element('del')
         return self.append_elems(el, self.render_inner(token))
 
     def render_image(self, token):
         # note that the attributes are sorted before output HTML,
         # NOT by the order specified. annoying when taking diffs,
         # requiring a customized HTML serializer
-        el = etree.Element('img', src=token.src, alt=self.render_to_plain(token))
+        el = ET.Element('img', src=token.src, alt=self.render_to_plain(token))
         if token.title:
             el.set('title', self.escape_html(token.title))
         return el
 
     def render_link(self, token):
-        el = etree.Element('a', href=self.escape_url(token.target))
+        el = ET.Element('a', href=self.escape_url(token.target))
         if token.title:
             el.set('title', self.escape_html(token.title))
         self.append_elems(el, self.render_inner(token))
         return el
 
     def render_auto_link(self, token):
-        el = etree.Element('a')
+        el = ET.Element('a')
         if token.mailto:
             target = 'mailto:{}'.format(token.target)
         else:
@@ -284,12 +285,12 @@ class ETreeRenderer(BaseRenderer):
         return AtomicString(self.escape_html(token.content))
 
     def render_heading(self, token):
-        el = etree.Element('h{}'.format(token.level))
+        el = ET.Element('h{}'.format(token.level))
         self.append_elems(el, self.render_inner(token))
         return el
 
     def render_quote(self, token):
-        el = etree.Element('blockquote')
+        el = ET.Element('blockquote')
         el.text = '\n'
         self._suppress_ptag_stack.append(False)
         self.append_elems(el, self.render_inner_join(token))
@@ -309,12 +310,12 @@ class ETreeRenderer(BaseRenderer):
             # take place.
             return self.render_inner(token)
         else:
-            el = etree.Element('p')
+            el = ET.Element('p')
             return self.append_elems(el, self.render_inner(token))
 
     def render_block_code(self, token):
-        el_pre = etree.Element('pre')
-        el_code = etree.SubElement(el_pre, 'code')
+        el_pre = ET.Element('pre')
+        el_code = ET.SubElement(el_pre, 'code')
         if token.language:
             el_code.set('class', 'language-{}'.format(self.escape_html(token.language)))
         # to comply with the format using in PythonMarkdown.
@@ -329,11 +330,11 @@ class ETreeRenderer(BaseRenderer):
 
     def render_list(self, token):
         if token.start is not None:
-            el = etree.Element('ol')
+            el = ET.Element('ol')
             if token.start != 1:
                 el.set('start', str(token.start))
         else:
-            el = etree.Element('ul')
+            el = ET.Element('ul')
 
         el.text = '\n'
 
@@ -345,7 +346,7 @@ class ETreeRenderer(BaseRenderer):
         return el
 
     def render_list_item(self, token):
-        el = etree.Element('li')
+        el = ET.Element('li')
         if not token.children:
             return el
 
@@ -370,16 +371,16 @@ class ETreeRenderer(BaseRenderer):
         #
         # The primary difficulty seems to be passing down alignment options to
         # reach individual cells.
-        el = etree.Element('table')
+        el = ET.Element('table')
         el.text = '\n'
         if hasattr(token, 'header'):
-            thead = etree.SubElement(el, 'thead')
+            thead = ET.SubElement(el, 'thead')
             thead.text = '\n'
             thead.tail = '\n'
             row = self.render_table_row(token.header, is_header=True)
             thead.append(row)
 
-        tbody = etree.SubElement(el, 'tbody')
+        tbody = ET.SubElement(el, 'tbody')
         tbody.text = '\n'
         tbody.tail = '\n'
         self.append_elems(tbody, self.render_inner(token))
@@ -387,7 +388,7 @@ class ETreeRenderer(BaseRenderer):
         return el
 
     def render_table_row(self, token, is_header=False):
-        el = etree.Element('tr')
+        el = ET.Element('tr')
         el.text = '\n'
         el.tail = '\n'
         inner = [self.render_table_cell(child, is_header)
@@ -395,7 +396,7 @@ class ETreeRenderer(BaseRenderer):
         return self.append_elems(el, inner)
 
     def render_table_cell(self, token, in_header=False):
-        el = etree.Element('th' if in_header else 'td')
+        el = ET.Element('th' if in_header else 'td')
         el.tail = '\n'
 
         if token.align is None:
@@ -410,21 +411,21 @@ class ETreeRenderer(BaseRenderer):
     def render_document(self, token):
         self.footnotes.update(token.footnotes)
         # python-markdown recognizes and strips *this* hardcoded <div>
-        el = etree.Element(getattr(token, 'root_tag', 'div'))
+        el = ET.Element(getattr(token, 'root_tag', 'div'))
         self.append_elems(el, self.render_inner_join(token))
         self.append_newline_inside(el)
-        elt = etree.ElementTree(el)
+        elt = ET.ElementTree(el)
         return elt
 
     @staticmethod
     def render_thematic_break(token):
-        return etree.Element('hr')
+        return ET.Element('hr')
 
     @staticmethod
     def render_line_break(token):
         if token.soft:
             return AtomicString('\n')
-        el = etree.Element('br')
+        el = ET.Element('br')
         el.tail = '\n'
         return el
 
@@ -586,7 +587,7 @@ class MarkdownInterop(markdown.Markdown):
             return ''  # a blank unicode string
 
         try:
-            source = util.text_type(source)
+            source = str(source)
         except UnicodeDecodeError as e:  # pragma: no cover
             # Customise error message while maintaining original trackback
             e.reason += '. -- Note: Markdown only accepts unicode input!'

--- a/mkdocs_plugin_commonmark/mistletoe_interop.py
+++ b/mkdocs_plugin_commonmark/mistletoe_interop.py
@@ -21,7 +21,7 @@ import markdown
 from markdown import util
 from markdown.util import etree, text_type, AtomicString
 
-from mistletoe import (Document, block_tokenizer, block_token, span_token)
+from mistletoe import (Document, block_tokenizer, block_token, span_token, token)
 from mistletoe.block_token import _token_types as _block_token_types
 from . import serializers
 
@@ -102,6 +102,7 @@ class DocumentLazy(Document):
 
             block_token._root_node = self
             span_token._root_node = self
+            token._root_node = self
             yield self
         finally:
             block_token._root_node = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,20 @@
-mkdocs>=1.1.2
-Markdown>=3.2.1
-mistletoe>=0.7.2
+mkdocs==1.1.2
+Markdown>=3.2.1,<=3.2.2
+mistletoe==0.7.2
+setuptools==46.4.0
+
+# transitive dependencies, newest versions as of 2020-05-18:
+click==7.1.2
+future==0.18.2
+jinja2==2.11.2
+joblib==0.15.1
+livereload==2.6.1
+lunr==0.5.8
+markupsafe==1.1.1
+mkdocs-plugin-commonmark==0.0.4
+nltk==3.5
+pyyaml==5.3.1
+regex==2020.5.14
+six==1.14.0
+tornado==6.0.4
+tqdm==4.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.1.2
-Markdown>=3.2.1,<=3.2.2
-mistletoe==0.7.2
+mkdocs<1.5
+Markdown>=3.2.1,<3.3
+mistletoe<1.4
 setuptools
 
 # transitive dependencies, newest working versions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs<1.6
+mkdocs>=1.4
 Markdown>=3.2.1,<3.4
 mistletoe>=1.4
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Markdown>=3.2.1,<=3.2.2
 mistletoe==0.7.2
 setuptools==46.4.0
 
-# transitive dependencies, newest versions as of 2020-05-18:
-jinja2==2.11.2
-markupsafe==1.1.1
+# transitive dependencies, newest working versions
+jinja2==2.11.3
+markupsafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,3 @@ mkdocs<1.5
 Markdown>=3.2.1
 mistletoe>=1.4
 setuptools
-
-# transitive dependencies, newest working versions
-jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs<1.5
 Markdown>=3.2.1,<3.3
-mistletoe<1.4
+mistletoe>=1.4
 setuptools
 
 # transitive dependencies, newest working versions

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ mistletoe==0.7.2
 setuptools==46.4.0
 
 # transitive dependencies, newest working versions
-jinja2==2.11.3
-markupsafe==2.0.1
+jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mkdocs==1.1.2
 Markdown>=3.2.1,<=3.2.2
 mistletoe==0.7.2
-setuptools==46.4.0
+setuptools
 
 # transitive dependencies, newest working versions
 jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs<1.5
-Markdown>=3.2.1,<3.3
+Markdown>=3.2.1
 mistletoe>=1.4
 setuptools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,5 @@ mistletoe==0.7.2
 setuptools==46.4.0
 
 # transitive dependencies, newest versions as of 2020-05-18:
-click==7.1.2
-future==0.18.2
 jinja2==2.11.2
-joblib==0.15.1
-livereload==2.6.1
-lunr==0.5.8
 markupsafe==1.1.1
-mkdocs-plugin-commonmark==0.0.4
-nltk==3.5
-pyyaml==5.3.1
-regex==2020.5.14
-six==1.14.0
-tornado==6.0.4
-tqdm==4.46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs>=1.4
-Markdown>=3.2.1,<3.4
+Markdown>=3.2.1
 mistletoe>=1.4
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs<1.5
-Markdown>=3.2.1
+mkdocs<1.6
+Markdown>=3.2.1,<3.4
 mistletoe>=1.4
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,16 @@ setuptools.setup(
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/soxhub/mkdocs-plugin-commonmark",
-    python_requires=">=3.4",
+    python_requires=">=3.4,<3.10",
     include_package_data=True,
     install_requires=open("requirements.txt", "r").readlines(),
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setuptools.setup(
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/soxhub/mkdocs-plugin-commonmark",
-    python_requires=">=3.4,<3.10",
+    # Markdown<3.3 is incompatible with Python>=3.12
+    python_requires=">=3.4,<3.12",
     include_package_data=True,
     install_requires=open("requirements.txt", "r").readlines(),
     classifiers=[
@@ -29,5 +30,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ]
 )


### PR DESCRIPTION
Easily tested with:
```bash
uvx \
  --with=git+https://github.com/akaihola/mkdocs-plugin-commonmark@newest-working-dependencies \
  mkdocs
```

Minimum versions are now:
- mkdocs 1.4
- Markdown 3.2.1
- mistletoe 1.4

Maximum versions:
- Python 3.11.x

Fixes made to the plugin:
- handle `span_token.Image` specially in `render_to_plain()` (just return an empty string)
  - the return value of `render_to_plain()` doesn't seem to affect behavior at all – this is very unclear to me, clarification needed
- also assign the current `DocumentLazy` object to `mistletoe.token._root_node` – fixes an exception with footnotes
  - this I don't understand completely, hope it's correct
- mkdocs `Page` monkeypatch no longer copies the whole `render` function, just monkeypatches `markdown.Markdown` with MarkdownInterop`
- migrate away from `markdown.util.etree` and `markdown.util.text_type` as instructed in Markdown release notes