### PR TITLE
Limit versions of dependencies to newest as of 2020-05-18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,20 @@
-mkdocs>=1.1.2
-Markdown>=3.2.1
-mistletoe>=0.7.2
+mkdocs==1.1.2
+Markdown>=3.2.1,<=3.2.2
+mistletoe==0.7.2
+setuptools==46.4.0
+
+# transitive dependencies, newest versions as of 2020-05-18:
+click==7.1.2
+future==0.18.2
+jinja2==2.11.2
+joblib==0.15.1
+livereload==2.6.1
+lunr==0.5.8
+markupsafe==1.1.1
+mkdocs-plugin-commonmark==0.0.4
+nltk==3.5
+pyyaml==5.3.1
+regex==2020.5.14
+six==1.14.0
+tornado==6.0.4
+tqdm==4.46.0

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,16 @@ setuptools.setup(
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/soxhub/mkdocs-plugin-commonmark",
-    python_requires=">=3.4",
+    python_requires=">=3.4,<3.10",
     include_package_data=True,
     install_requires=open("requirements.txt", "r").readlines(),
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ]
 )


### PR DESCRIPTION
Also add setuptools and limit Python to 3.9 and older.

These changes allow installing and running the plugin successfully in 2025 again.